### PR TITLE
Replace lazy and/or hack with a ternary

### DIFF
--- a/jenkins_jobs_slack/slack.py
+++ b/jenkins_jobs_slack/slack.py
@@ -31,7 +31,7 @@ def slack_properties(parser, xml_parent, data):
                       ('notify-failure', 'notifyFailure'),
                       ('notify-backtonormal', 'notifyBackToNormal')):
         (XML.SubElement(notifier, attr)
-         .text) = data.get(opt, True) and 'true' or 'false'
+         .text) = 'true' if data.get(opt, True) else 'false'
 
 
 def slack_publisher(parser, xml_parent, data):


### PR DESCRIPTION
A Python ternary is a lot easier to read than using Python's lazy evaluation of `and`s and `or`s
