### PR TITLE
'include-custom-message: true' is now mandatory attribute for working with 'custom-message' attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Slack publisher and config for jenkins job builder
             room: '#jenkins'
             token: secret
             team-domain: example.com
+            include-custom-message: true
             custom-message: message
 
       publishers:


### PR DESCRIPTION
starting from version 0.3.2 jenkins-jobs-slack requires 'include-custom-message: true' for working with 'custom-message' field
