### PR TITLE
Updating to reflect changes in Jenkins plugin for Slack 2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# IntelliJ
+idea/

--- a/README.md
+++ b/README.md
@@ -6,27 +6,22 @@ Slack publisher and config for jenkins job builder
 
     - project:
       name: foo
-      properties:
-        - slack:
-            notify-start: true
-            notify-success: true
-            notify-aborted: true
-            notify-notbuilt: true
-            notify-unstable: true
-            notify-failure: true
-            notify-backtonormal: true
-            notify-repeatedfailure: true
-            include-test-summary: true
-            show-commit-list: true
-            room: '#jenkins'
-            token: secret
-            team-domain: example.com
-            include-custom-message: true
-            custom-message: message
-
       publishers:
-        - slack:
-            team-domain: example.com
-            auth-token: secret
-            build-server-url: https://jenkins.example.com
-            room: '#jenkins'
+          - slack:
+              team-domain: example.com
+              auth-token: secret
+              build-server-url: https://jenkins.example.com
+              room: '#jenkins'
+              notify-start: true
+              notify-success: true
+              notify-aborted: true
+              notify-notbuilt: true
+              notify-unstable: true
+              notify-failure: true
+              notify-backtonormal: true
+              notify-repeatedfailure: true
+              include-test-summary: true
+              commit-info-choice: NONE | AUTHORS | AUTHORS_AND_TITLES
+              include-custom-message: true
+              custom-message: message
+

--- a/jenkins_jobs_slack/slack.py
+++ b/jenkins_jobs_slack/slack.py
@@ -1,61 +1,5 @@
 import xml.etree.ElementTree as XML
 
-
-def slack_properties(parser, xml_parent, data):
-    """yaml: slack
-
-    Example::
-
-      properties:
-        - slack:
-            notify-start: true
-            notify-success: true
-            notify-aborted: true
-            notify-notbuilt: true
-            notify-unstable: true
-            notify-failure: true
-            notify-backtonormal: true
-            notify-repeatedfailure: true
-            include-test-summary: true
-            show-commit-list: true
-            include-custom-message: true
-            room: '#jenkins'
-            token: secret
-            team-domain: example.com
-            custom-message: message
-    """
-    if data is None:
-        data = dict()
-
-    notifier = XML.SubElement(
-        xml_parent, 'jenkins.plugins.slack.SlackNotifier_-SlackJobProperty')
-    notifier.set('plugin', 'slack@1.8')
-
-    for opt, attr in (('notify-start', 'startNotification'),
-                      ('notify-success', 'notifySuccess'),
-                      ('notify-aborted', 'notifyAborted'),
-                      ('notify-notbuilt', 'notifyNotBuilt'),
-                      ('notify-unstable', 'notifyUnstable'),
-                      ('notify-failure', 'notifyFailure'),
-                      ('notify-backtonormal', 'notifyBackToNormal'),
-                      ('notify-repeatedfailure', 'notifyRepeatedFailure'),
-                      ('include-test-summary', 'includeTestSummary'),
-                      ('show-commit-list', 'showCommitList'),
-                      ('include-custom-message', 'includeCustomMessage')):
-        (XML.SubElement(notifier, attr)
-         .text) = 'true' if data.get(opt, True) else 'false'
-
-    for opt, attr in (('team-domain', 'teamDomain'),
-                      ('token', 'token'),
-                      ('room', 'room')):
-        (XML.SubElement(notifier, attr)
-         .text) = data.get(opt)
-
-    if data.get('include-custom-message'):
-        (XML.SubElement(notifier, 'customMessage')
-         .text) = data.get('custom-message')
-
-
 def slack_publisher(parser, xml_parent, data):
     """yaml: slack
 
@@ -67,16 +11,47 @@ def slack_publisher(parser, xml_parent, data):
             auth-token: secret
             build-server-url: https://jenkins.example.com
             room: '#jenkins'
+            notify-start: true
+            notify-success: true
+            notify-aborted: true
+            notify-notbuilt: true
+            notify-unstable: true
+            notify-failure: true
+            notify-backtonormal: true
+            notify-repeatedfailure: true
+            include-test-summary: true
+            commit-info-choice: NONE | AUTHORS | AUTHORS_AND_TITLES
+            include-custom-message: true
+            custom-message: message
+
     """
     if data is None:
         data = dict()
 
     notifier = XML.SubElement(
         xml_parent, 'jenkins.plugins.slack.SlackNotifier')
-    notifier.set('plugin', 'slack@1.8')
+    notifier.set('plugin', 'slack@2.0.1')
 
     for (opt, attr) in (('team-domain', 'teamDomain'),
                         ('auth-token', 'authToken'),
                         ('build-server-url', 'buildServerUrl'),
-                        ('room', 'room')):
-        XML.SubElement(notifier, attr).text = data.get(opt, '')
+                        ('room', 'room'),
+                        ('commit-info-choice', 'commitInfoChoice')):
+        (XML.SubElement(notifier, attr).text) = data.get(opt)
+
+    for (opt, attr) in (('notify-start', 'startNotification'),
+                        ('notify-success', 'notifySuccess'),
+                        ('notify-aborted', 'notifyAborted'),
+                        ('notify-notbuilt', 'notifyNotBuilt'),
+                        ('notify-unstable', 'notifyUnstable'),
+                        ('notify-failure', 'notifyFailure'),
+                        ('notify-backtonormal', 'notifyBackToNormal'),
+                        ('notify-repeatedfailure', 'notifyRepeatedFailure'),
+                        ('include-test-summary', 'includeTestSummary'),
+                        ('include-custom-message', 'includeCustomMessage')):
+        (XML.SubElement(notifier, attr)
+         .text) = 'true' if data.get(opt, True) else 'false'
+
+    if data.get('include-custom-message'):
+        (XML.SubElement(notifier, 'customMessage')
+         .text) = data.get('custom-message')

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='jenkins-jobs-slack',
-    version='0.3.2',
+    version='0.3.3',
     description='Jenkins Job Builder Slack Notifier',
     url='https://github.com/asmundg/jenkins-jobs-slack',
     author='Aasmund Grammeltvedt',
@@ -10,8 +10,6 @@ setup(
     license='MIT license',
     install_requires=[],
     entry_points={
-        'jenkins_jobs.properties': [
-            'slack = jenkins_jobs_slack.slack:slack_properties'],
         'jenkins_jobs.publishers': [
             'slack = jenkins_jobs_slack.slack:slack_publisher']},
     packages=['jenkins_jobs_slack'],


### PR DESCRIPTION
2.0 seems to have moved all options to the publisher and did away with the properties section.  The updates here reflect those changes and correct issues with bad job configs being generated when using slack notifiers.
